### PR TITLE
fix: Prevent .mcp.json overwrite in manual_test_init tool

### DIFF
--- a/src/tools/generators/file-content-generator.ts
+++ b/src/tools/generators/file-content-generator.ts
@@ -8,7 +8,6 @@ import type { InitProjectInput } from '../../models';
 export interface FileContentGenerator {
   generateReadme(input: InitProjectInput): string;
   generateTestCaseTemplate(): string;
-  generateMcpConfig(): object;
 }
 
 /**
@@ -162,17 +161,6 @@ notes: |
 `;
   }
 
-  generateMcpConfig(): object {
-    return {
-      mcpServers: {
-        'manual-tests': {
-          type: 'stdio',
-          command: 'npx',
-          args: ['github:70-10/manual-tests-mcp']
-        }
-      }
-    };
-  }
 }
 
 // Default generator instance

--- a/src/tools/managers/file-system-manager.ts
+++ b/src/tools/managers/file-system-manager.ts
@@ -93,8 +93,7 @@ export class DirectoryStructure {
     return {
       projectMeta: 'tests/manual-tests/project-meta.yml',
       readme: 'tests/manual-tests/README.md',
-      template: 'tests/manual-tests/templates/test-case-template.yml',
-      mcpConfig: '.mcp.json'
+      template: 'tests/manual-tests/templates/test-case-template.yml'
     };
   }
 }

--- a/src/tools/manual-test-init.ts
+++ b/src/tools/manual-test-init.ts
@@ -50,12 +50,8 @@ export async function initProject(input: InitProjectInput): Promise<InitResult> 
     await defaultFileSystemManager.writeTextFile(filePaths.template, templateContent);
     createdFiles.push(filePaths.template);
 
-    // Create MCP config if requested
-    if (input.mcpConfig) {
-      const mcpConfig = defaultFileContentGenerator.generateMcpConfig();
-      await defaultFileSystemManager.writeJsonFile(filePaths.mcpConfig, mcpConfig);
-      createdFiles.push(filePaths.mcpConfig);
-    }
+    // Note: MCP config generation has been disabled to prevent overwriting existing .mcp.json files
+    // Users should manually configure their .mcp.json file according to the README instructions
 
     return {
       success: true,

--- a/tests/tools/manual-test-init-refactor.test.ts
+++ b/tests/tools/manual-test-init-refactor.test.ts
@@ -129,15 +129,6 @@ describe('manual-test-init refactored components', () => {
       expect(template).toContain('{{test_data.users.valid_user.username}}');
     });
 
-    it('should generate MCP config', () => {
-      const config = generator.generateMcpConfig();
-
-      expect(config).toHaveProperty('mcpServers');
-      expect(config).toHaveProperty('mcpServers.manual-tests');
-      expect((config as any).mcpServers['manual-tests'].type).toBe('stdio');
-      expect((config as any).mcpServers['manual-tests'].command).toBe('npx');
-      expect((config as any).mcpServers['manual-tests'].args).toContain('github:70-10/manual-tests-mcp');
-    });
   });
 
   describe('InitInputValidator', () => {
@@ -264,7 +255,6 @@ describe('manual-test-init refactored components', () => {
       expect(paths.projectMeta).toBe('tests/manual-tests/project-meta.yml');
       expect(paths.readme).toBe('tests/manual-tests/README.md');
       expect(paths.template).toBe('tests/manual-tests/templates/test-case-template.yml');
-      expect(paths.mcpConfig).toBe('.mcp.json');
     });
   });
 });

--- a/tests/tools/manual-test-init.test.ts
+++ b/tests/tools/manual-test-init.test.ts
@@ -135,7 +135,7 @@ describe('manual-test-init', () => {
         expect(content).toContain('sample_product:');
       });
 
-      it('MCP設定ファイルを作成する', async () => {
+      it('mcpConfig オプションが設定されても .mcp.json ファイルは作成されない', async () => {
         const input: InitProjectInput = {
           projectName: 'test-project',
           baseUrl: 'https://example.com',
@@ -146,18 +146,12 @@ describe('manual-test-init', () => {
 
         expect(result.success).toBe(true);
         if (result.success) {
-          expect(result.createdFiles).toContain('.mcp.json');
+          expect(result.createdFiles).not.toContain('.mcp.json');
         }
 
         const mcpConfigPath = '.mcp.json';
         const exists = await fs.pathExists(mcpConfigPath);
-        expect(exists).toBe(true);
-
-        const content = await fs.readFile(mcpConfigPath, 'utf-8');
-        const config = JSON.parse(content);
-        expect(config.mcpServers).toBeDefined();
-        expect(config.mcpServers['manual-tests']).toBeDefined();
-        expect(config.mcpServers['manual-tests'].type).toBe('stdio');
+        expect(exists).toBe(false);
       });
     });
 
@@ -322,23 +316,6 @@ describe('manual-test-init', () => {
         expect(content).toContain('username_field:');
       });
 
-      it('MCP設定が正しく生成される', async () => {
-        const input: InitProjectInput = {
-          projectName: 'mcp-test',
-          baseUrl: 'https://mcp.com',
-          mcpConfig: true
-        };
-
-        const result = await initProject(input);
-
-        expect(result.success).toBe(true);
-
-        const content = await fs.readFile('.mcp.json', 'utf-8');
-        const config = JSON.parse(content);
-        
-        expect(config.mcpServers['manual-tests'].command).toBe('npx');
-        expect(config.mcpServers['manual-tests'].args).toContain('github:70-10/manual-tests-mcp');
-      });
     });
   });
 });


### PR DESCRIPTION
## Summary
- Remove MCP config file generation from manual_test_init tool to prevent overwriting existing .mcp.json files
- Disable generateMcpConfig() method and related functionality
- Update test cases to verify .mcp.json files are not created when mcpConfig option is used

## Changes Made
- **manual-test-init.ts**: Removed MCP config file creation logic, added explanatory comment
- **file-content-generator.ts**: Removed generateMcpConfig() method and interface definition
- **file-system-manager.ts**: Removed mcpConfig path from getFilePaths()
- **Tests**: Updated test cases to verify .mcp.json files are not created

## Problem Solved
The manual_test_init tool was previously overwriting existing .mcp.json files when the mcpConfig option was enabled. This could destroy users' custom MCP server configurations. Now the tool safely skips .mcp.json generation and directs users to configure it manually according to README instructions.

## Test Plan
- [x] All existing tests pass with updated expectations
- [x] mcpConfig option no longer creates .mcp.json files
- [x] TypeScript compilation succeeds
- [x] No breaking changes to the public API

🤖 Generated with [Claude Code](https://claude.ai/code)